### PR TITLE
camera: Add support for sending raw commands

### DIFF
--- a/core/java/android/hardware/Camera.java
+++ b/core/java/android/hardware/Camera.java
@@ -997,6 +997,12 @@ public class Camera {
     private native void enableFocusMoveCallback(int enable);
 
     /**
+     * Send a raw command to the camera driver
+     * @hide
+     */
+    public native void sendRawCommand(int arg1, int arg2, int arg3);
+
+    /**
      * Callback interface used to signal the moment of actual image capture.
      *
      * @see #takePicture(ShutterCallback, PictureCallback, PictureCallback, PictureCallback)

--- a/core/jni/android_hardware_Camera.cpp
+++ b/core/jni/android_hardware_Camera.cpp
@@ -848,6 +848,17 @@ static void android_hardware_Camera_enableFocusMoveCallback(JNIEnv *env, jobject
     }
 }
 
+static void android_hardware_Camera_sendRawCommand(JNIEnv *env, jobject thiz, jint arg1, jint arg2, jint arg3)
+{
+    ALOGV("sendRawCommand %d, %d, %d", arg1, arg2, arg3);
+    sp<Camera> camera = get_native_camera(env, thiz, NULL);
+    if (camera == 0) return;
+
+    if (camera->sendCommand(arg1, arg2, arg3) != NO_ERROR) {
+        jniThrowRuntimeException(env, "send raw command failed");
+    }
+}
+
 //-------------------------------------------------
 
 static JNINativeMethod camMethods[] = {
@@ -929,6 +940,9 @@ static JNINativeMethod camMethods[] = {
   { "enableFocusMoveCallback",
     "(I)V",
     (void *)android_hardware_Camera_enableFocusMoveCallback},
+  { "sendRawCommand",
+    "(III)V",
+    (void *)android_hardware_Camera_sendRawCommand},
 };
 
 struct field {


### PR DESCRIPTION
- Certain camera drivers need magic commands to select special modes
  such as ZSL or HDR. Add support for sending raw commands from
  applications.

Change-Id: I512a765c7a67ffd2877e465cf6493ffc2b3b54ac
