### PR TITLE
HALO: Option to pause the underlying app (1/2)

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -2579,6 +2579,13 @@ public final class Settings {
         public static final String HALO_HIDE = "halo_hide";
 
         /**
+         * HALO pause activities?, defaults to 0 (no, do not pause) on devices which isLargeRAM() == true
+         * otherwise it defaults to 1 (yes, do pause)
+         * @hide
+         */
+        public static final String HALO_PAUSE = "halo_pause";
+
+        /**
          * Pie menu, should default to 1 (yes, show)
          * @hide
          */

--- a/services/java/com/android/server/am/ActivityStack.java
+++ b/services/java/com/android/server/am/ActivityStack.java
@@ -56,6 +56,7 @@ import android.os.PowerManager;
 import android.os.RemoteException;
 import android.os.SystemClock;
 import android.os.UserHandle;
+import android.provider.Settings;
 import android.util.DisplayMetrics;
 import android.util.EventLog;
 import android.util.ExtendedPropertiesUtils;
@@ -1529,7 +1530,7 @@ final class ActivityStack {
         
         // We need to start pausing the current activity so the top one
         // can be resumed...
-        if (mResumedActivity != null && !next.floatingWindow) {
+        if (mResumedActivity != null && (pauseActiveAppWhenUsingHalo() || !next.floatingWindow)) {
             if (DEBUG_SWITCH) Slog.v(TAG, "Skip resume: need to start pausing");
             // At this point we want to put the upcoming activity's process
             // at the top of the LRU list, since we know we will be needing it
@@ -4748,7 +4749,13 @@ final class ActivityStack {
 
         return true;
     }
-    
+
+    private boolean pauseActiveAppWhenUsingHalo() {
+        int isLowRAM = (ActivityManager.isLargeRAM()) ? 0 : 1;
+        return Settings.System.getInt(mContext.getContentResolver(),
+                Settings.System.HALO_PAUSE, isLowRAM) == 1;
+    }
+
     public void dismissKeyguardOnNextActivityLocked() {
         mDismissKeyguardOnNextActivity = true;
     }


### PR DESCRIPTION
DO NOT MERGE YET. Please try this out first.
I've been porting this over from my CM10.1 based Halo build.

This adds an option to pause the active app when using HALO.
I've enabled the option by default for devices with low memory. (Do you want that?)
I'm currently using the ActivityManager.isLargeRAM() function which will return true if the device got at least 640MB RAM available to the kernel.

I can customize / enable / disable the default behaviour if you'd like.
But I think it makes sense not to use two foreground activities on older devices which don't have enough RAM (at least by default, users can still change the option if they want).

Please give me some feedback - what do you guys think? :)

Cheers,
tonyp
