### PR TITLE
Build fixes for Brightness Controls (1/2)

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -2760,6 +2760,12 @@ public final class Settings {
         public static final String STATUS_BAR_DONOTDISTURB = "status_bar_donotdisturb";
 
         /**
+         * Show the brightness controls in status bar (or not)
+         * @hide
+         */
+        public static final String STATUS_BAR_BRIGHTNESS_CONTROL = "status_bar_brightness_control";
+
+        /**
          * Maximal notification count as overlays on the status bar
          * @hide
          */

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -2760,7 +2760,7 @@ public final class Settings {
         public static final String STATUS_BAR_DONOTDISTURB = "status_bar_donotdisturb";
 
         /**
-         * Show the brightness controls in status bar (or not)
+         * Enables adjusting brightness by sliding status bar
          * @hide
          */
         public static final String STATUS_BAR_BRIGHTNESS_CONTROL = "status_bar_brightness_control";


### PR DESCRIPTION
Added the missing string for the Brightness Control feature to Settings.java, and then edited the description in the 2nd commit.
