### PR TITLE
Fix floating window activity result cancellation

### DIFF
--- a/services/java/com/android/server/am/ActivityRecord.java
+++ b/services/java/com/android/server/am/ActivityRecord.java
@@ -428,7 +428,6 @@ final class ActivityRecord {
                 intent.setFlags(intent.getFlags() & ~Intent.FLAG_ACTIVITY_TASK_ON_HOME);
                 intent.setFlags(intent.getFlags() & ~Intent.FLAG_ACTIVITY_SINGLE_TOP);
                 intent.addFlags(Intent.FLAG_ACTIVITY_NO_USER_ACTION);
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 
                 // If this is the mother-intent we make it volatile
                 if (topIntent) {


### PR DESCRIPTION
Setting Intent.FLAG_ACTIVITY_NEW_TASK on _all_ floating window intents
will result in Android dropping activity results for non-new task
activities trying to get results back.

Cheers,
SlimRoms

Change-Id: Ib125bd03733dc73859f7426150110d88319f7625
