### PR TITLE
FLAG_ACTIVITY_NEW_TASK re-added to floating windows

### DIFF
--- a/services/java/com/android/server/am/ActivityRecord.java
+++ b/services/java/com/android/server/am/ActivityRecord.java
@@ -428,6 +428,7 @@ final class ActivityRecord {
                 intent.setFlags(intent.getFlags() & ~Intent.FLAG_ACTIVITY_TASK_ON_HOME);
                 intent.setFlags(intent.getFlags() & ~Intent.FLAG_ACTIVITY_SINGLE_TOP);
                 intent.addFlags(Intent.FLAG_ACTIVITY_NO_USER_ACTION);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 
                 // If this is the mother-intent we make it volatile
                 if (topIntent) {

--- a/services/java/com/android/server/am/ActivityStack.java
+++ b/services/java/com/android/server/am/ActivityStack.java
@@ -2773,7 +2773,8 @@ final class ActivityStack {
             launchFlags |= Intent.FLAG_ACTIVITY_NEW_TASK;
         }
 
-        if (r.resultTo != null && (launchFlags&Intent.FLAG_ACTIVITY_NEW_TASK) != 0) {
+        if (r.resultTo != null && (launchFlags&Intent.FLAG_ACTIVITY_NEW_TASK) != 0 &&
+                (launchFlags&Intent.FLAG_FLOATING_WINDOW) == 0) {
             // For whatever reason this activity is being launched into a new
             // task...  yet the caller has requested a result back.  Well, that
             // is pretty messed up, so instead immediately send back a cancel


### PR DESCRIPTION
ActivityStack modified to not cancel results if window is floating and "new".
## 

Aaron merged the original patch for testing -- however he also mentioned that removing FLAG_ACTIVITY_NEW_TASK causes some apps (G+?) to not quit halo when pressing outside of the window.  Should that be the case with the changes I made that were recently merged, _this_ should return the behavior back to what was originally intended as well as address the activity result cancellation issue the original patch was created to fix.
