### PR TITLE
Gesture Fix v2

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/halo/Halo.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/halo/Halo.java
@@ -730,8 +730,14 @@ public class Halo extends FrameLayout implements Ticker.TickerCallback, TabletTi
 
                         boolean gestureChanged = false;
                         final int deltaIndex = (Math.abs(deltaY) - verticalThreshold) / verticalSteps;
-                        if (deltaY > 0) {                           
-                            if (deltaIndex < 2 && mGesture != Gesture.UP1) {
+                        if (deltaY > 0) { 
+                            if (deltaIndex < 1 && mGesture != Gesture.NONE) {
+                                // Dead zone buffer to prevent accidental notifiction dismissal
+                                mGesture = Gesture.NONE;
+                                gestureChanged = true;
+                                mEffect.setHaloOverlay(HaloProperties.Overlay.NONE, 0f);
+                                gestureText = "";
+                            } else if (deltaIndex == 1 && mGesture != Gesture.UP1) {
                                 mGesture = Gesture.UP1;
                                 gestureChanged = true;
                                 mEffect.setHaloOverlay(HaloProperties.Overlay.DISMISS, 1f);


### PR DESCRIPTION
- Add a buffer zone between the HALO bubble and the first vertical up marker,
  reduces sensitivity of UP1 gesture preventing accidental notification dismissal.
