### PR TITLE
Completely hide Halo))) icons while tasking

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/halo/Halo.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/halo/Halo.java
@@ -459,8 +459,11 @@ public class Halo extends FrameLayout implements Ticker.TickerCallback, TabletTi
         final float originalAlpha = mContext.getResources().getFraction(R.dimen.status_bar_icon_drawing_alpha, 1, 1);
         for (int i = 0; i < mNotificationData.size(); i++) {
             NotificationData.Entry entry = mNotificationData.get(i);
-            if (entry.notification.pkg.equals("com.paranoid.halo")) continue;
-            entry.icon.setAlpha(originalAlpha);
+            if (entry.notification.pkg.equals("com.paranoid.halo")) {
+                entry.icon.setAlpha(0);
+            } else {
+                entry.icon.setAlpha(originalAlpha);
+            }
         }
     }
 
@@ -492,7 +495,9 @@ public class Halo extends FrameLayout implements Ticker.TickerCallback, TabletTi
 
                 mMarkerIndex = -1;
                 oldIconIndex = -1;
-                
+
+                resetIcons();
+
                 mGesture = Gesture.NONE;
                 hiddenState = (mState == State.HIDDEN || mState == State.SILENT);
                 if (hiddenState) {


### PR DESCRIPTION
- previous commit by BigBrother1984 stopped the highlighting of Halo))) icons
  this should remove them completely. Other status bar icons are still highlighted
