### PR TITLE
Quick Settings: Option to use floating window (2/2)

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -2916,6 +2916,13 @@ public final class Settings {
          * @hide
          */
         public static final String QS_COLLAPSE_PANEL = "qs_collapse_panel";
+        
+        /**
+         * Quick Settings Launch in Floating Window
+         * 
+         * @hide
+         */
+        public static final String QS_FLOATING_WINDOW = "qs_floating_window";
 
         /**
          * Use the Notification Power Widget? (Who wouldn't!)

--- a/packages/SystemUI/src/com/android/systemui/quicksettings/QuickSettingsTile.java
+++ b/packages/SystemUI/src/com/android/systemui/quicksettings/QuickSettingsTile.java
@@ -94,6 +94,11 @@ public class QuickSettingsTile implements OnClickListener {
         } catch (RemoteException e) {
         }
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        ContentResolver resolver = mContext.getContentResolver();
+        boolean floatingWindow = Settings.System.getBoolean(resolver, Settings.System.QS_FLOATING_WINDOW, false) == true;
+        if (floatingWindow) {
+            intent.addFlags(Intent.FLAG_FLOATING_WINDOW);
+        }
         mContext.startActivityAsUser(intent, new UserHandle(UserHandle.USER_CURRENT));
         mStatusbarService.collapse();
     }


### PR DESCRIPTION
Allows the option of launching preferences from the quicksettings menu in a
floating window

Depends on settings pull request

Change-Id: Ie54545a4dc423484b6106a540f106467c25d8c49
Signed-off-by: Evan Anderson evan1124@gmail.com
