### PR TITLE
Allow USB notification to show when primary SD allows UMS and MTP

### DIFF
--- a/services/java/com/android/server/usb/UsbDeviceManager.java
+++ b/services/java/com/android/server/usb/UsbDeviceManager.java
@@ -194,13 +194,25 @@ public class UsbDeviceManager {
         mNotificationManager = (NotificationManager)
                 mContext.getSystemService(Context.NOTIFICATION_SERVICE);
 
-        // We do not show the USB notification if the primary volume supports mass storage.
-        // The legacy mass storage UI will be used instead.
+        // We do not show the USB notification if the primary volume supports mass storage, unless
+        // persist.sys.usb.config is set to mtp,adb. This will allow the USB notification to show
+        // on devices with mtp as default and mass storage enabled on primary, so the user can choose
+        // between mtp, ptp, and mass storage. The legacy mass storage UI will be used otherwise.
         boolean massStorageSupported = false;
         final StorageManager storageManager = StorageManager.from(mContext);
         final StorageVolume primary = storageManager.getPrimaryVolume();
-        massStorageSupported = primary != null && primary.allowMassStorage();
-        mUseUsbNotification = !massStorageSupported;
+
+        if (Settings.Secure.getInt(mContentResolver, Settings.Secure.USB_MASS_STORAGE_ENABLED, 0 ) == 1 ) {
+                massStorageSupported = primary != null && primary.allowMassStorage();
+        } else {
+                massStorageSupported = false;
+        }
+
+        if ("mtp,adb".equals(SystemProperties.get("persist.sys.usb.config"))) {
+            mUseUsbNotification = true;
+        } else {
+            mUseUsbNotification = !massStorageSupported;
+        }
 
         // make sure the ADB_ENABLED setting value matches the current state
         Settings.Global.putInt(mContentResolver, Settings.Global.ADB_ENABLED, mAdbEnabled ? 1 : 0);


### PR DESCRIPTION
Previously if primary SD is set to allowMassStorage="true" the USB
dialog would never show.  This checks if persist.sys.usb.config is
set to mtp,adb and then allows the USB notification to show. With
this you can then have the option to select from MTP, PTP and Mass
storage when clicking the pull down notification. When Mass Storage
is selected it activates the USB connected dialog to turn on USB
storage. When set back to MTP the USB connected notification disappears.

Change-Id: I2287075ec93cae75f19e8fb59965d9dddb234aca
