### PR TITLE
Add LTE QS tile (1/2) and DSPManager build error fix

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -2866,42 +2866,42 @@ public final class Settings {
          * Quick Settings Panel Tiles to Use
          * @hide
          */
-        public static final String QUICK_SETTINGS = "quick_settings";
+        public static final String QUICK_SETTINGS_TILES = "quick_settings";
 
         /**
          * Quick Settings Panel Dynamic Tiles
          *
          * @hide
          */
-        public static final String QS_DYNAMIC_ALARM = "qs_dyanmic_alarm";
+        public static final String QS_DYNAMIC_ALARM = "qs_dynamic_alarm";
 
         /**
          * Quick Settings Panel Dynamic Tiles
          *
          * @hide
          */
-        public static final String QS_DYNAMIC_BUGREPORT = "qs_dyanmic_bugreport";
+        public static final String QS_DYNAMIC_BUGREPORT = "qs_dynamic_bugreport";
 
         /**
          * Quick Settings Panel Dynamic Tiles
          *
          * @hide
          */
-        public static final String QS_DYNAMIC_IME = "qs_dyanmic_ime";
+        public static final String QS_DYNAMIC_IME = "qs_dynamic_ime";
 
         /**
          * Quick Settings Panel Dynamic Tiles
          *
          * @hide
          */
-        public static final String QS_DYNAMIC_USBTETHER = "qs_dyanmic_usbtether";
+        public static final String QS_DYNAMIC_USBTETHER = "qs_dynamic_usbtether";
 
         /**
          * Quick Settings Panel Dynamic Tiles
          *
          * @hide
          */
-        public static final String QS_DYNAMIC_WIFI = "qs_dyanmic_wifi";
+        public static final String QS_DYNAMIC_WIFI = "qs_dynamic_wifi";
 
         /**
          * Quick Settings Quick Pulldown

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -2770,6 +2770,12 @@ public final class Settings {
         public static final String VOLBTN_MUSIC_CONTROLS = "volbtn_music_controls";
 
         /**
+         * Whether or not to launch default music player when headset is connected
+         * @hide
+         */
+        public static final String HEADSET_CONNECT_PLAYER = "headset_connect_player";
+
+        /**
          * Whether to enable quiet hours.
          * @hide
          */

--- a/packages/SystemUI/src/com/android/systemui/quicksettings/LteTile.java
+++ b/packages/SystemUI/src/com/android/systemui/quicksettings/LteTile.java
@@ -1,0 +1,111 @@
+package com.android.systemui.quicksettings;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.provider.Settings;
+import android.telephony.TelephonyManager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.View.OnClickListener;
+
+import com.android.internal.telephony.Phone;
+import com.android.systemui.R;
+import com.android.systemui.statusbar.phone.QuickSettingsContainerView;
+import com.android.systemui.statusbar.phone.QuickSettingsController;
+
+import java.util.List;
+
+public class LteTile extends QuickSettingsTile {
+
+    private Context mContext;
+
+    public LteTile(Context context, QuickSettingsController qsc) {
+        super(context, qsc);
+
+        mContext = context;
+
+        mOnClick = new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                toggleLteState();
+                updateResources();
+            }
+        };
+
+        mOnLongClick = new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View v) {
+                Intent intent = new Intent(Intent.ACTION_MAIN);
+                intent.setClassName("com.android.phone", "com.android.phone.Settings");
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                startSettingsActivity(intent);
+                return true;
+            }
+        };
+
+        qsc.registerObservedContent(Settings.Global.getUriFor(Settings.Global.PREFERRED_NETWORK_MODE), this);
+    }
+
+    @Override
+    void onPostCreate() {
+        updateTile();
+        super.onPostCreate();
+    }
+
+    @Override
+    public void onChangeUri(ContentResolver resolver, Uri uri) {
+        updateResources();
+    }
+
+    @Override
+    public void updateResources() {
+        updateTile();
+        super.updateResources();
+    }
+
+    private synchronized void updateTile() {
+        int network = getCurrentPreferredNetworkMode(mContext);
+        switch(network) {
+            case Phone.NT_MODE_GLOBAL:
+            case Phone.NT_MODE_LTE_CDMA_AND_EVDO:
+            case Phone.NT_MODE_LTE_GSM_WCDMA:
+            case Phone.NT_MODE_LTE_CMDA_EVDO_GSM_WCDMA:
+            case Phone.NT_MODE_LTE_ONLY:
+            case Phone.NT_MODE_LTE_WCDMA:
+                mDrawable = R.drawable.ic_qs_lte_on;
+                mLabel = mContext.getString(R.string.quick_settings_lte);
+                break;
+            default:
+                mDrawable = R.drawable.ic_qs_lte_off;
+                mLabel = mContext.getString(R.string.quick_settings_lte_off);
+                break;
+        }
+    }
+
+    private void toggleLteState() {
+        TelephonyManager tm = (TelephonyManager)
+            mContext.getSystemService(Context.TELEPHONY_SERVICE);
+        int network = getCurrentPreferredNetworkMode(mContext);
+        switch(network) {
+            case Phone.NT_MODE_GLOBAL:
+            case Phone.NT_MODE_LTE_CDMA_AND_EVDO:
+            case Phone.NT_MODE_LTE_GSM_WCDMA:
+            case Phone.NT_MODE_LTE_CMDA_EVDO_GSM_WCDMA:
+            case Phone.NT_MODE_LTE_ONLY:
+            case Phone.NT_MODE_LTE_WCDMA:
+                tm.toggleLTE(false);
+                break;
+            default:
+                tm.toggleLTE(true);
+                break;
+        }
+    }
+
+    private static int getCurrentPreferredNetworkMode(Context context) {
+        int network = Settings.Global.getInt(context.getContentResolver(),
+                    Settings.Global.PREFERRED_NETWORK_MODE, -1);
+        return network;
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -2718,7 +2718,7 @@ protected WindowManager.LayoutParams getRecentsLayoutParams(LayoutParams layoutP
         public void startObserving() {
             final ContentResolver cr = mContext.getContentResolver();
             cr.registerContentObserver(
-                    Settings.System.getUriFor(Settings.System.QUICK_SETTINGS),
+                    Settings.System.getUriFor(Settings.System.QUICK_SETTINGS_TILES),
                     false, this);
 
             cr.registerContentObserver(

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/QuickSettingsController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/QuickSettingsController.java
@@ -28,6 +28,7 @@ import static com.android.internal.util.cm.QSConstants.TILE_LOCKSCREEN;
 import static com.android.internal.util.cm.QSConstants.TILE_MOBILEDATA;
 import static com.android.internal.util.cm.QSConstants.TILE_NETWORKMODE;
 import static com.android.internal.util.cm.QSConstants.TILE_NFC;
+import static com.android.internal.util.cm.QSConstants.TILE_LTE;
 import static com.android.internal.util.cm.QSConstants.TILE_RINGER;
 import static com.android.internal.util.cm.QSConstants.TILE_SCREENTIMEOUT;
 import static com.android.internal.util.cm.QSConstants.TILE_SETTINGS;
@@ -43,6 +44,7 @@ import static com.android.internal.util.cm.QSConstants.TILE_HYBRID;
 import static com.android.internal.util.cm.QSUtils.deviceSupportsBluetooth;
 import static com.android.internal.util.cm.QSUtils.deviceSupportsMobileData;
 import static com.android.internal.util.cm.QSUtils.deviceSupportsUsbTether;
+import static com.android.internal.util.cm.QSUtils.deviceSupportsLte;
 
 import android.content.BroadcastReceiver;
 import android.content.ContentResolver;
@@ -67,6 +69,7 @@ import com.android.systemui.quicksettings.BrightnessTile;
 import com.android.systemui.quicksettings.BugReportTile;
 import com.android.systemui.quicksettings.GPSTile;
 import com.android.systemui.quicksettings.InputMethodTile;
+import com.android.systemui.quicksettings.LteTile;
 import com.android.systemui.quicksettings.MobileNetworkTile;
 import com.android.systemui.quicksettings.MobileNetworkTypeTile;
 import com.android.systemui.quicksettings.NfcTile;
@@ -126,6 +129,7 @@ public class QuickSettingsController {
         // Filter items not compatible with device
         boolean bluetoothSupported = deviceSupportsBluetooth();
         boolean mobileDataSupported = deviceSupportsMobileData(mContext);
+        boolean lteSupported = deviceSupportsLte(mContext);
 
         if (!bluetoothSupported) {
             TILES_DEFAULT.remove(TILE_BLUETOOTH);
@@ -137,10 +141,14 @@ public class QuickSettingsController {
             TILES_DEFAULT.remove(TILE_NETWORKMODE);
         }
 
+        if (!lteSupported) {
+            TILES_DEFAULT.remove(TILE_LTE);
+        }
+
         // Read the stored list of tiles
         ContentResolver resolver = mContext.getContentResolver();
         LayoutInflater inflater = LayoutInflater.from(mContext);
-        String tiles = Settings.System.getString(resolver, Settings.System.QUICK_SETTINGS);
+        String tiles = Settings.System.getString(resolver, Settings.System.QUICK_SETTINGS_TILES);
 
         if (tiles == null) {
             Log.i(TAG, "Default tiles being loaded");
@@ -197,6 +205,8 @@ public class QuickSettingsController {
                     qs = new DesktopModeTile(mContext, this, mHandler);
             } else if (tile.equals(TILE_HYBRID)) {
                 qs = new HybridTile(mContext, this, mHandler);
+            } else if (tile.equals(TILE_LTE)) {
+                qs = new LteTile(mContext, this);
             }
             if (qs != null) {
                 qs.setupQuickSettingsTile(inflater, mContainerView);

--- a/packages/SystemUI/src/com/android/systemui/statusbar/tablet/NotificationPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/tablet/NotificationPanel.java
@@ -522,7 +522,7 @@ public class NotificationPanel extends RelativeLayout implements StatusBarPanel,
         public void startObserving() {
             final ContentResolver cr = mContext.getContentResolver();
             cr.registerContentObserver(
-                    Settings.System.getUriFor(Settings.System.QUICK_SETTINGS),
+                    Settings.System.getUriFor(Settings.System.QUICK_SETTINGS_TILES),
                     false, this);
 
             cr.registerContentObserver(

--- a/telephony/java/android/telephony/TelephonyManager.java
+++ b/telephony/java/android/telephony/TelephonyManager.java
@@ -678,6 +678,14 @@ public class TelephonyManager {
         }
     }
 
+    public void toggleLTE(boolean on) {
+        try {
+            getITelephony().toggleLTE(on);
+        } catch (RemoteException e) {
+            //Silently fail
+        }
+    }
+
     /** Unknown network class. {@hide} */
     public static final int NETWORK_CLASS_UNKNOWN = 0;
     /** Class of broadly defined "2G" networks. {@hide} */

--- a/telephony/java/com/android/internal/telephony/ITelephony.aidl
+++ b/telephony/java/com/android/internal/telephony/ITelephony.aidl
@@ -45,6 +45,12 @@ interface ITelephony {
     void call(String callingPackage, String number);
 
     /**
+     * Toggle between 3G and LTE (NT_MODE_CDMA, NT_MODE_GLOBAL)
+     * @param boolean to turn on and off LTE
+     */
+    void toggleLTE(boolean on);
+
+    /**
      * If there is currently a call in progress, show the call screen.
      * The DTMF dialpad may or may not be visible initially, depending on
      * whether it was up when the user last exited the InCallScreen.


### PR DESCRIPTION
The LTE tile was cherry-picked from CM. Corrected a few misspellings.

Also adds the settings piece to allow building of DSPManager.
