### PR TITLE
Fix Overflow Toggle

### DIFF
--- a/core/java/android/view/ViewConfiguration.java
+++ b/core/java/android/view/ViewConfiguration.java
@@ -670,16 +670,6 @@ public class ViewConfiguration {
      * @return true if a permanent menu key is present, false otherwise.
      */
     public boolean hasPermanentMenuKey() {
-        IWindowManager wm = WindowManagerGlobal.getWindowManagerService();
-        // Report no menu key if device has soft buttons
-        try {
-            if (wm.hasSystemNavBar() || wm.hasNavigationBar()) {
-                return false;
-            }
-        } catch (RemoteException ex) {
-            // do nothing, continue trying to guess
-        }
-
         // Report no menu key if overflow button is forced to enabled
         ContentResolver res = mContext.getContentResolver();
         boolean forceOverflowButton = Settings.System.getInt(res,
@@ -689,6 +679,7 @@ public class ViewConfiguration {
         }
 
         // Report menu key presence based on hardware key rebinding
+        IWindowManager wm = WindowManagerGlobal.getWindowManagerService();
         try {
             return wm.hasMenuKeyEnabled();
         } catch (RemoteException ex) {


### PR DESCRIPTION
The values for hasSystemNavBar() & hasNavigationBar() are always true in PA, as a result the overflow is always shown, so remove this check.
