### PR TITLE
fix Typo on OpenGLRenderer (libhwui) Properties

### DIFF
--- a/core/java/android/app/ActivityManager.java
+++ b/core/java/android/app/ActivityManager.java
@@ -383,8 +383,8 @@ public class ActivityManager {
     static public boolean isHighEndGfx() {
         MemInfoReader reader = new MemInfoReader();
         reader.readMemInfo();
-        if (reader.getTotalSize() >= (512*1024*1024)) {
-            // If the device has at least 512MB RAM available to the kernel,
+        if (reader.getTotalSize() >= (256*1024*1024)) {
+            // If the device has at least 256MB RAM available to the kernel,
             // we can afford the overhead of graphics acceleration.
             return true;
         }

--- a/libs/hwui/Properties.h
+++ b/libs/hwui/Properties.h
@@ -137,7 +137,7 @@ enum DebugLevel {
 #define PROPERTY_FBO_CACHE_SIZE "ro.hwui.fbo_cache_size"
 
 // These properties are defined in percentage (range 0..1)
-#define PROPERTY_TEXTURE_CACHE_FLUSH_RATE "ro.hwui.texture_cache_flushrate"
+#define PROPERTY_TEXTURE_CACHE_FLUSH_RATE "ro.hwui.texture_cache_flush_rate"
 
 // These properties are defined in pixels
 #define PROPERTY_TEXT_SMALL_CACHE_WIDTH "ro.hwui.text_small_cache_width"


### PR DESCRIPTION
See: http://code.google.com/p/android/issues/detail?id=60165

In file

https://android.googlesource.com/platform/docs/source.android.com/+/master/src/devices/tuning.jd

Line 109 says property is called "texture_cache_flush_rate" however in the code it is called "texture_cache_flushrate". See that in file

https://android.googlesource.com/platform/frameworks/base/+/master/libs/hwui/Properties.h

Change-Id: I4b6aff888608e9d7c9de66421f68114081250b9b
